### PR TITLE
Feature/semantics funcdecs

### DIFF
--- a/decs.ml
+++ b/decs.ml
@@ -97,19 +97,18 @@ let get_func_table (func_dec : func_decl) global_scope =
   let formals_scope = List.fold_left get_bind_decs {
     variables = StringMap.empty;
     parent = None;
-  } func_dec.formals in 
+  } func_dec.formals in
+  let updated_scope = { 
+    variables = formals_scope.variables;
+    parent = Some(global_scope); } in
   let locals_scope = List.fold_left get_stmt_decs {
     variables = StringMap.empty;
-    parent = Some(formals_scope);
+    parent = Some(updated_scope);
   } func_dec.body in
-  let ty = func_dec.typ 
-  and updated_scope = { 
-    variables = formals_scope.variables;
-    parent = Some(global_scope); } 
-  in {
+  {
     formals = updated_scope;
     locals = locals_scope;
-    ret_typ = ty;
+    ret_typ = func_dec.typ;
   }
 
 let get_decs (s_list, f_list) = 

--- a/decs.ml
+++ b/decs.ml
@@ -21,10 +21,10 @@ type func_table = {
 }
 
 let rec string_of_params params = match params with
-  (typ, _) :: [] -> string_of_typ typ ^ ")"
-  | (typ, _) :: p -> string_of_typ typ ^ ", " ^ string_of_params p
-  | _             -> ")" 
-and key_string name params = name ^ " (" ^ string_of_params params 
+    (typ, _) :: [] -> string_of_typ typ
+  | (typ, _) ::  p -> string_of_typ typ ^ ", " ^ string_of_params p
+  | _              -> "" 
+and key_string name params = name ^ " (" ^ string_of_params params ^ ")"
 
 let rec is_valid_dec name scope = 
   if StringMap.mem name scope.variables then
@@ -48,85 +48,82 @@ let rec get_expr_decs scope expr =
     variables = StringMap.empty;
     parent = Some(scope);
   } in match expr with
-    Binop(e1, _, e2) -> 
-      let expr_list = [e1; e2] in List.fold_left get_expr_decs scope expr_list
-  | Unop(_, e) -> get_expr_decs scope e
-  | Ternop(e1, e2, e3) -> 
-      let expr_list = [e1; e2; e3] in List.fold_left get_expr_decs scope expr_list
-  | OpAssign(_, _, e)
-  | Assign(_, e) -> get_expr_decs scope e
-  | DecAssign(ty, name, e) -> 
-      let updated_scope = get_expr_decs scope e in add_symbol name ty updated_scope
-  | Deconstruct(b_list, e) -> 
-      let updated_scope = List.fold_left get_bind_decs scope b_list in get_expr_decs updated_scope e
-  | Access(arr, index) ->
-      let expr_list = [arr; index] in List.fold_left get_expr_decs scope expr_list
-  | AccessAssign(e1, e2, e3) ->
-      let expr_list = [e1; e2; e3] in List.fold_left get_expr_decs scope expr_list
-  | Call(_, expr_list) -> List.fold_left get_expr_decs scope expr_list
-  | AttributeCall(e1, _, e_list) -> 
-      let expr_list = e1 :: e_list in List.fold_left (get_expr_decs) scope expr_list
-  | _ -> scope
+      Binop(e1, _, e2) -> 
+        let expr_list = [e1; e2] in List.fold_left get_expr_decs scope expr_list
+    | Unop(_, e) -> get_expr_decs scope e
+    | Ternop(e1, e2, e3) -> 
+        let expr_list = [e1; e2; e3] in List.fold_left get_expr_decs scope expr_list
+    | OpAssign(_, _, e)
+    | Assign(_, e) -> get_expr_decs scope e
+    | DecAssign(ty, name, e) -> 
+        let updated_scope = get_expr_decs scope e in add_symbol name ty updated_scope
+    | Deconstruct(b_list, e) -> 
+        let updated_scope = List.fold_left get_bind_decs scope b_list in get_expr_decs updated_scope e
+    | Access(arr, index) ->
+        let expr_list = [arr; index] in List.fold_left get_expr_decs scope expr_list
+    | AccessAssign(e1, e2, e3) ->
+        let expr_list = [e1; e2; e3] in List.fold_left get_expr_decs scope expr_list
+    | Call(_, expr_list) -> List.fold_left get_expr_decs scope expr_list
+    | AttributeCall(e1, _, e_list) -> 
+        let expr_list = e1 :: e_list in List.fold_left (get_expr_decs) scope expr_list
+    | _ -> scope
 
 let rec get_stmt_decs scope stmt =
   let new_scope = {
     variables = StringMap.empty;
     parent = Some(scope);
   } in match stmt with
-    Block(s_list) -> 
-      let _ = List.fold_left get_stmt_decs new_scope s_list in scope
-  | Expr(e) -> get_expr_decs scope e
-  | Dec(ty, name) -> add_symbol name ty scope
-  | If(cond, then_s, else_s) -> 
-      let cond_scope = get_expr_decs new_scope cond in
-      let _ = (get_stmt_decs cond_scope then_s, get_stmt_decs cond_scope else_s) in scope
-  | For(e1, e2, e3, s) -> 
-      let expr_list = [e1; e2; e3] in
-      let for_scope = List.fold_left get_expr_decs new_scope expr_list in 
-      let _ = get_stmt_decs for_scope s in scope
-  | DecForIter(ty, name, e, s) -> 
-      let iter_scope = add_symbol name ty new_scope in
-      let for_scope = get_expr_decs iter_scope e in 
-      let _ = get_stmt_decs for_scope s in scope
-  | While(e, s) -> 
-      let while_scope = get_expr_decs new_scope e in 
-      let _ = get_stmt_decs while_scope s in scope
-  | _ -> scope
+      Block(s_list) -> 
+        let _ = List.fold_left get_stmt_decs new_scope s_list in scope
+    | Expr(e) -> get_expr_decs scope e
+    | Dec(ty, name) -> add_symbol name ty scope
+    | If(cond, then_s, else_s) -> 
+        let cond_scope = get_expr_decs new_scope cond in
+        let _ = (get_stmt_decs cond_scope then_s, get_stmt_decs cond_scope else_s) in scope
+    | For(e1, e2, e3, s) -> 
+        let expr_list = [e1; e2; e3] in
+        let for_scope = List.fold_left get_expr_decs new_scope expr_list in 
+        let _ = get_stmt_decs for_scope s in scope
+    | DecForIter(ty, name, e, s) -> 
+        let iter_scope = add_symbol name ty new_scope in
+        let for_scope = get_expr_decs iter_scope e in 
+        let _ = get_stmt_decs for_scope s in scope
+    | While(e, s) -> 
+        let while_scope = get_expr_decs new_scope e in 
+        let _ = get_stmt_decs while_scope s in scope
+    | _ -> scope
 
-let get_func_table (func_dec : func_decl) global_scope = 
-  let formals_scope = List.fold_left get_bind_decs {
+let get_vars scope s_list = List.fold_left get_stmt_decs scope s_list
+
+let build_func_table global_scope (fd : func_decl) map = 
+  let key = key_string fd.fname fd.formals in
+  if StringMap.mem key map then 
+    raise (Failure("Error: function " ^ fd.fname ^ " is already defined with formal arguments (" ^ 
+    (string_of_params fd.formals) ^ ")"))
+  else let formals_scope = List.fold_left get_bind_decs {
     variables = StringMap.empty;
     parent = None;
-  } func_dec.formals in
+  } fd.formals in
   let updated_scope = { 
     variables = formals_scope.variables;
     parent = Some(global_scope); } in
-  let locals_scope = List.fold_left get_stmt_decs {
+  let locals_scope = get_vars {
     variables = StringMap.empty;
     parent = Some(updated_scope);
-  } func_dec.body in
-  {
+  } fd.body in StringMap.add key {
     formals = updated_scope;
     locals = locals_scope;
-    ret_typ = func_dec.typ;
-  }
+    ret_typ = fd.typ;
+  } map
 
 let get_decs (s_list, f_list) = 
 
-  let get_vars stmts = 
-    List.fold_left get_stmt_decs {
-      variables = StringMap.empty;
-      parent = None;
-    } stmts in
+  let globals = get_vars {
+    variables = StringMap.empty;
+    parent = None;
+  } (List.rev s_list) in
 
-  (* TODO : major cleanup, duplicate checking for overloaded funcs *)
+  let get_funcs f_list = 
+    List.fold_left (fun m f -> build_func_table globals f m) StringMap.empty f_list
 
-  let globals = get_vars (List.rev s_list) in
-  let add_func_dec map func_dec global_scope = 
-    let key = key_string func_dec.fname func_dec.formals
-    and func_table = get_func_table func_dec global_scope
-    in StringMap.add key func_table map
-  in let get_funcs fd_list globs = 
-    List.fold_left (fun map fd -> add_func_dec map fd globs) StringMap.empty fd_list
-
-in let _ = (globals, get_funcs f_list globals) in (s_list, f_list)
+in (globals, get_funcs f_list)

--- a/decs.ml
+++ b/decs.ml
@@ -1,15 +1,17 @@
 (* * * * *
-  This file semantically checks all variable declarations in the AST.
-  Duplicate variables and nah declarations throw errors.
-  A scoped symbol table mapping variable names to their types is returned.
+  This file semantically checks all variable and function declarations in the AST.
+  Duplicate variables, nah variable declarations, and function declarations
+  with the same parameters throw errors.
+  A scoped symbol table mapping variable names to their types is returned, along with  
+  a mapping of functions to their scoped formal and local variables.
 * * * * *)
 
 open Ast
 
 module StringMap = Map.Make(String)
-type symbol_table = {
+type scope_table = {
   variables : typ StringMap.t;
-  parent : symbol_table option;
+  parent : scope_table option;
 }
 
 let rec is_valid_dec name scope = 

--- a/test/samples/dup_vars.vp
+++ b/test/samples/dup_vars.vp
@@ -39,11 +39,28 @@ if (int b = 1) {
 int a22 = 1;
 int j = 2;
 
-int func foo(int a, int b, int j) {
-    int c;
+int func foo(int a, int[] b, int j) {
+    int functest;
     for (int i = 0; i < 5; i++) {
         string x = "for";
         int array2;
     }
     return 0;
+}
+
+int func foo(int a, int b, int j) {
+    int functest;
+    return 0;
+}
+
+int func foo() {
+    return 4;
+}
+
+string func woo() {
+    return "";
+}
+
+string func woo(float a) {
+    return "wow";
 }

--- a/test/samples/dup_vars.vp
+++ b/test/samples/dup_vars.vp
@@ -37,9 +37,13 @@ if (int b = 1) {
     string param3 = "";
 }
 int a22 = 1;
-int i = 2;
+int j = 2;
 
-int func foo(int a, int b) {
-    int i;
+int func foo(int a, int b, int j) {
+    int c;
+    for (int i = 0; i < 5; i++) {
+        string x = "for";
+        int array2;
+    }
     return 0;
 }

--- a/test/samples/dup_vars.vp
+++ b/test/samples/dup_vars.vp
@@ -40,5 +40,6 @@ int a22 = 1;
 int i = 2;
 
 int func foo(int a, int b) {
+    int i;
     return 0;
 }

--- a/viper.ml
+++ b/viper.ml
@@ -24,8 +24,8 @@
      in
      let lexbuf = Lexing.from_channel channel in
      let ast = Parser.program Scanner.token lexbuf in
-     let decs = Decs.get_decs ast in
-     let sast = Semant.check decs in
+     let (var_decs, func_decs) = Decs.get_decs ast in
+     let sast = Semant.check ast in
      match !action with
        Ast -> print_string (Ast.string_of_program ast)
       | _  -> print_string("Not supported")


### PR DESCRIPTION
This pull request extracts function declarations from the AST. Errors are thrown if any two functions have the same name and parameters, or if there are illegal variable declarations in the function bodies. A map of function declarations is built, where the keys are unique strings that include parameters to allow overloading, and the values are `func_tables`, which hold formal variables, local variables, and return type. For example, the entry for the function
```
int func sum(int a, int b) {
    int c = a + b;
    return c;
}
```
uses `"sum (int,  int)"` as a key, which maps to
```
formals: int a, int b
locals: int c
ret_typ: int
```