### PR TITLE
AST Cleanup

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,6 @@ all : viper.native
 viper.native :
 	ocamlbuild -use-ocamlfind -pkgs llvm,llvm.analysis -cflags -w,+a-4 \
 		viper.native
-	cp viper.native ../viper.native
 
 # "make clean" removes all generated files
 

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -53,6 +53,7 @@ type expr =
 
 type stmt =
     Block of stmt list
+  | PretendBlock of stmt list
   | Expr of expr
   | Dec of typ * string
   | Return of expr
@@ -149,6 +150,7 @@ let rec string_of_expr = function
 let rec string_of_stmt = function
     Block(stmts) ->
       "{\n" ^ String.concat "" (List.map string_of_stmt stmts) ^ "}\n"
+  | PretendBlock(stmts) -> "\n" ^ String.concat "" (List.map string_of_stmt stmts) ^ "\n" 
   | Expr(expr) -> string_of_expr expr ^ ";\n";
   | Dec(t, v) -> string_of_typ t ^ " " ^ v ^ ";\n";
   | Return(expr) -> "return " ^ string_of_expr expr ^ ";\n";

--- a/src/sast.ml
+++ b/src/sast.ml
@@ -16,7 +16,6 @@ and sx =
   | SId of string
   | SBinop of sexpr * op * sexpr
   | SUnop of uop * sexpr
-  | STernop of sexpr * sexpr * sexpr
 
   | SAssign of string * sexpr
   | SDeconstruct of bind list * sexpr

--- a/src/sast.ml
+++ b/src/sast.ml
@@ -25,11 +25,6 @@ and sx =
   | SAccess of sexpr * sexpr
   | SAccessAssign of sexpr * sexpr * sexpr
 
-  | SMatchPattern of sexpr list * sexpr
-  | SConditionalPattern of sexpr * sexpr
-  | SPatternMatch of string * sexpr
-  | SDecPatternMatch of typ * string * sexpr
-
   | SCall of string * sexpr list
   | SAttributeCall of sexpr * string * sexpr list
 
@@ -44,10 +39,6 @@ type sstmt =
   | SAbort of sexpr
   | SPanic of sexpr
   | SIf of sexpr * sstmt * sstmt
-  | SFor of sexpr * sexpr * sexpr * sstmt
-  | SForIter of string * sexpr * sstmt
-  | SDecForIter of typ * string * sexpr * sstmt
-  | SDeconstForIter of bind list * sexpr * sstmt
   | SWhile of sexpr * sstmt
 
 type sfunc_decl = {
@@ -55,7 +46,6 @@ type sfunc_decl = {
   sfname : string;
   sformals : bind list;
   sbody : sstmt list;
-  sautoreturn : bool;
 }
 
 type sprogram = sstmt list * sfunc_decl list

--- a/src/sast.ml
+++ b/src/sast.ml
@@ -38,6 +38,9 @@ type sstmt =
   | SAbort of sexpr
   | SPanic of sexpr
   | SIf of sexpr * sstmt * sstmt
+  | SForIter of string * sexpr * sstmt
+  | SDecForIter of typ * string * sexpr * sstmt
+  | SDeconstForIter of bind list * sexpr * sstmt
   | SWhile of sexpr * sstmt
 
 type sfunc_decl = {

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -17,7 +17,7 @@ let clean_pattern s e = match e with
 let clean_expression expr = match expr with
     PatternMatch(s, e) -> clean_pattern s e
   | DecPatternMatch(t, s, e) -> Block([ Dec(t, s); clean_pattern s e;  ])
-  | _ -> Expr(Noexpr)
+  | _ -> Expr(expr)
 
 let clean_statements stmts = 
     let rec clean_statement stmt = match stmt with

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -1,9 +1,28 @@
 (* Semantic checking for the MicroC compiler *)
 
+open Ast
 let placeholderCheck ast = ast
 
+let rec clean_expression expr = match expr with
+    Ternop(e1, e2, e3) -> ()
+  | PatternMatch(s, e) -> ()
+  | DecPatternMatch(t, s, e) -> ()
+
+let rec clean_statements stmts = match stmts with
+    Block(stmts) -> Block(List.map clean_statements stmts)
+  | Expr(expr) -> clean_expression expr
+  | For(e1, e2, e3, s) -> ()
+  | ForIter(name, e2, s) -> ()
+  | DecForIter(t, name, e2, s) -> ()
+  | DeconstForIter(p, expr, s) -> ()
+
+let reshape_arrow_function fdecl = fdecl
+
+let clean_function fdecl = (if fdecl.autoreturn then reshape_arrow_function fdecl else fdecl)
+
+let desugar (stmts, functions) = (clean_statements stmts, (List.map clean_function functions))
+
 (*
-open Ast
 open Sast
 
 module StringMap = Map.Make(String)

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -19,7 +19,7 @@ let rec clean_statements stmts = match stmts with
 
 let reshape_arrow_function fdecl = ignore (fdecl.body = Return(List.hd fdecl.body)); ignore (fdecl.autoreturn = false); fdecl
 
-let clean_function fdecl = (if fdecl.autoreturn then reshape_arrow_function fdecl else fdecl)
+let clean_function fdecl = if fdecl.autoreturn then reshape_arrow_function fdecl else (ignore(fdecl.body = clean_statements fdecl.body); fdecl)
 
 let desugar (stmts, functions) = (clean_statements stmts, (List.map clean_function functions))
 

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -3,10 +3,17 @@
 open Ast
 let placeholderCheck ast = ast
 
-let clean_pattern_match s e = ()
+let rec clean_pattern_rec s e base = match e with
+    ConditionalPattern(cond, exp) :: tail -> If(cond, Assign(s, exp), clean_pattern_rec tail)
+  | ConditionalPattern(cond, exp) :: [] -> If(cond, Assign(s, exp), Assign(s, base))
+  | _ -> ()
+
+let clean_pattern s e = match e with
+    MatchPattern(pattern, base) -> clean_pattern_rec s pattern base
+  | _ -> ()
 
 let rec clean_expression expr = match expr with
-  | PatternMatch(s, e) -> clean_pattern_match s e
+  | PatternMatch(s, e) -> clean_pattern s e
   | DecPatternMatch(t, s, e) -> Block([ Dec(t, s); clean_pattern_match s e;  ])
 
 let rec clean_statements stmts = match stmts with

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -3,20 +3,21 @@
 open Ast
 let placeholderCheck ast = ast
 
+let clean_pattern_match s e = ()
+
 let rec clean_expression expr = match expr with
-    Ternop(e1, e2, e3) -> ()
-  | PatternMatch(s, e) -> ()
-  | DecPatternMatch(t, s, e) -> ()
+  | PatternMatch(s, e) -> clean_pattern_match s e
+  | DecPatternMatch(t, s, e) -> Block([ Dec(t, s); clean_pattern_match s e;  ])
 
 let rec clean_statements stmts = match stmts with
     Block(stmts) -> Block(List.map clean_statements stmts)
   | Expr(expr) -> clean_expression expr
-  | For(e1, e2, e3, s) -> ()
+  | For(e1, e2, e3, s) -> Block([ Expr(e1); While(e2, Block([ s; e3;  ]))  ])
   | ForIter(name, e2, s) -> ()
   | DecForIter(t, name, e2, s) -> ()
   | DeconstForIter(p, expr, s) -> ()
 
-let reshape_arrow_function fdecl = fdecl
+let reshape_arrow_function fdecl = ignore (fdecl.body = Return(List.hd fdecl.body)); ignore (fdecl.autoreturn = false); fdecl
 
 let clean_function fdecl = (if fdecl.autoreturn then reshape_arrow_function fdecl else fdecl)
 

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -20,9 +20,7 @@ let rec clean_statements stmts = match stmts with
     Block(stmts) -> Block(List.map clean_statements stmts)
   | Expr(expr) -> clean_expression expr
   | For(e1, e2, e3, s) -> Block([ Expr(e1); While(e2, Block([ s; e3;  ]))  ])
-  | ForIter(name, e2, s) -> ()
-  | DecForIter(t, name, e2, s) -> ()
-  | DeconstForIter(p, expr, s) -> ()
+  | _ -> stmts
 
 let reshape_arrow_function fdecl = ignore (fdecl.body = Return(List.hd fdecl.body)); ignore (fdecl.autoreturn = false); fdecl
 

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -6,8 +6,9 @@ let placeholderCheck ast = ast
 exception SemanticException of string
 
 let rec clean_pattern_rec s e base = match e with
-    ConditionalPattern(cond, exp) :: tail -> If(cond, Expr(Assign(s, exp)), clean_pattern_rec s tail base)
-  | ConditionalPattern(cond, exp) :: [] -> If(cond, Expr(Assign(s, exp)), Expr(Assign(s, base)))
+    ConditionalPattern(cond, exp) :: [] -> If(cond, Expr(Assign(s, exp)), Expr(Assign(s, base)))
+  | ConditionalPattern(cond, exp) :: tail -> If(cond, Expr(Assign(s, exp)), clean_pattern_rec s tail base)
+  | _ -> Expr(Noexpr)
 
 let clean_pattern s e = match e with
     MatchPattern(pattern, base) -> clean_pattern_rec s pattern base

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -16,7 +16,7 @@ let clean_pattern s e = match e with
 
 let clean_expression expr = match expr with
     PatternMatch(s, e) -> clean_pattern s e
-  | DecPatternMatch(t, s, e) -> Block([ Dec(t, s); clean_pattern s e;  ])
+  | DecPatternMatch(t, s, e) -> PretendBlock([ Dec(t, s); clean_pattern s e;  ])
   | _ -> Expr(expr)
 
 let clean_statements stmts = 

--- a/src/semant.ml
+++ b/src/semant.ml
@@ -23,7 +23,7 @@ let clean_statements stmts =
         Block(s) -> Block(List.map clean_statement s)
       | Expr(expr) -> clean_expression expr
       | For(e1, e2, e3, s) -> Block( [ Expr(e1); While(e2, Block([ s; Expr(e3); ]))  ])
-      | _ -> stmts
+      | _ -> stmt
     in
     (List.map clean_statement stmts) 
 

--- a/src/viper.ml
+++ b/src/viper.ml
@@ -25,10 +25,11 @@ let _ =
   let lexbuf = Lexing.from_channel channel in
   let ast = Parser.program Scanner.token lexbuf in
   (* this is sast, currently not used so replace _ with sast when used *)
-  let _ = Semant.placeholderCheck ast in
+  let desugared = Semant.desugar ast in
+  let _ = Semant.placeholderCheck desugared in
   match !action with
-    Ast -> print_string (Ast.string_of_program ast)
-  | LLVM_IR -> print_string (Llvm.string_of_llmodule (Codegen.translate ast))
-  | Compile -> let m = Codegen.translate ast in 
+    Ast -> print_string (Ast.string_of_program desugared)
+  | LLVM_IR -> print_string (Llvm.string_of_llmodule (Codegen.translate desugared))
+  | Compile -> let m = Codegen.translate desugared in 
     Llvm_analysis.assert_valid_module m;
     print_string (Llvm.string_of_llmodule m)


### PR DESCRIPTION
Cleans up the AST and removes syntactic sugar to make life easier from here on out. A few notes and a known issue:
1. To see what this does, run `./runtests.sh -t ast -v 1`
2. Our [SAST in this branch](https://github.com/raghavmecheri/viper/blob/feature/cleanup_ast/src/sast.ml) has been updated to only use the types we need
3. `ForIter`, `DecForIter` and `DeconstForIter` are not de-sugared yet. However, we can talk about this and see if we want to do this at a later stage - I need to be able to access the length of an iterable to do this. Once we have a standard way to do that (say, a `len()` function) then I should be able to implement these as well. CC: @Maxusmusti 
4. Everything happens in `semant.ml`, but we can move this around. It's also being called as a separate step in `viper.ml`, but we can change this too (I needed to test it lol)