### PR TITLE
collect global statements into main if main isn't defined

### DIFF
--- a/src/semantdriver.ml
+++ b/src/semantdriver.ml
@@ -4,13 +4,11 @@ open Boolcheck
 open Rhandlhand 
 open Decs 
  
-let check(statements, functions) = 
+let check (statements, functions) = 
 
 let symbol_table = get_decs (statements, functions) in
 
-
 let global_scope = fst symbol_table in
-
 
 let function_scopes = snd symbol_table in
 
@@ -228,4 +226,20 @@ in
 
 in 
 
-(List.map (check_stmt global_scope false) statements, List.map check_function functions)
+let sstatements = List.map (check_stmt global_scope false) statements in
+let sfuncs = List.map check_function functions in
+
+let rec has_main sfuncs = match sfuncs with
+    [] -> false
+  | sfd :: _ when sfd.sfname = "main" && sfd.styp = Function(Int) -> true
+  | sfd :: _ when sfd.sfname = "main" -> raise (Failure ("Error: function main must return type Int, not type " ^ string_of_typ sfd.styp))
+  | _ :: tail -> has_main tail in
+
+let updated_sfuncs = if has_main sfuncs then sfuncs else
+  { styp = Int;
+    sfname = "main";
+    sformals = [];
+    sbody = sstatements;
+  } :: sfuncs in
+
+(sstatements, updated_sfuncs)

--- a/test/semantsamples/test_main.vp
+++ b/test/semantsamples/test_main.vp
@@ -1,0 +1,5 @@
+int i = 1;
+
+int func main(string b) {
+    return 4;
+}


### PR DESCRIPTION
This PR adds a final semantic check to automatically collect global statements into an implicit main function if main isn't already defined. It also ensures that any user-defined main function returns type int. Global statements are still included in the SAST as a separate list of statements, but are now duplicated in a semantically-checked main function in the list of sfunc_decls.

Behavior to consider: What should be done if there are global statements _and_ a user-defined main function? These statements are still included in the SAST, but are not added into the user's previously-defined main function.